### PR TITLE
fix: define loop variable j to prevent ReferenceError

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const gap = [[0]];
 const areTouching = (first, second) => {
     for (let i = 0; i < first.length; ++i) {
         if (first[i] && first[i][first[i].length - 1] === 1) {
-            for (j = -1; j <= 1; ++j) {
+            for (let j = -1; j <= 1; ++j) {
                 if (second[i+j] && second[i+j][0] === 1) {
                     return true;
                 }


### PR DESCRIPTION
Hi, @hgcummings 

Thank you for creating this library — I recently used it and found it very helpful.

While running it in Chrome, I encountered a ReferenceError: j is not defined, which seems to occur in ES module or strict mode environments.

I’ve submitted a small fix in this PR to address the issue.

Thanks for your work! ㅎㅎ